### PR TITLE
fix: container integration

### DIFF
--- a/cdk/hls_constructs/aws_batch_job.py
+++ b/cdk/hls_constructs/aws_batch_job.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from aws_cdk import Aws, Size, aws_batch, aws_ecs, aws_iam, aws_logs
+from aws_cdk import Aws, Duration, Size, aws_batch, aws_ecs, aws_iam, aws_logs
 from constructs import Construct
 
 
@@ -99,6 +99,7 @@ class BatchJob(Construct):
                     log_group=self.log_group,
                 ),
             ),
+            timeout=Duration.hours(1),
             retry_attempts=retry_attempts,
             retry_strategies=[
                 aws_batch.RetryStrategy.of(
@@ -112,6 +113,7 @@ class BatchJob(Construct):
                     aws_batch.Reason.custom(on_reason="*"),
                 ),
             ],
+            propagate_tags=True,
         )
 
         # It's useful to have the ARN of the job definition _without_ the revision

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -218,6 +218,7 @@ class HlsViStack(Stack):
                 "PROCESSING_BUCKET_NAME": self.processing_bucket.bucket_name,
                 "PROCESSING_BUCKET_JOB_PREFIX": settings.PROCESSING_BUCKET_JOB_PREFIX,
                 "PROCESSING_BUCKET_INVENTORY_PREFIX": settings.PROCESSING_BUCKET_INVENTORY_PREFIX,
+                "OUTPUT_BUCKET": settings.OUTPUT_BUCKET_NAME,
                 "BATCH_QUEUE_NAME": self.batch_infra.queue.job_queue_name,
                 "BATCH_JOB_DEFINITION_NAME": self.processing_job.job_def.job_definition_name,
             },

--- a/src/queue_feeder/handler.py
+++ b/src/queue_feeder/handler.py
@@ -30,6 +30,7 @@ def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
     """
     bucket = os.environ["PROCESSING_BUCKET_NAME"]
     prefix = os.environ["PROCESSING_BUCKET_INVENTORY_PREFIX"]
+    output_bucket = os.environ["OUTPUT_BUCKET"]
     job_queue = os.environ["BATCH_QUEUE_NAME"]
     job_definition_name = os.environ["BATCH_JOB_DEFINITION_NAME"]
     max_active_jobs = int(os.environ["FEEDER_MAX_ACTIVE_JOBS"])
@@ -57,7 +58,9 @@ def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
     # FIXME: add a time check and abandon early if going to timeout
     for i, granule_id in enumerate(granule_ids):
         processing_event = GranuleProcessingEvent(granule_id=granule_id, attempt=0)
-        batch.submit_job(processing_event, force_fail=bool(i % 2))
+        batch.submit_job(
+            event=processing_event, output_bucket=output_bucket, force_fail=bool(i % 2)
+        )
 
     tracker.update_tracking(updated_tracking)
     return updated_tracking.to_dict()

--- a/src/queue_feeder/handler.py
+++ b/src/queue_feeder/handler.py
@@ -18,28 +18,20 @@ else:
     logging.basicConfig(level=logging.INFO)
 
 
-def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
-    """Queue feeder Lambda handler
-
-    The "event" payload contains,
-    ```
-    {
-        "granule_submit_count": 5000,
-    }
-    ```
-    """
-    bucket = os.environ["PROCESSING_BUCKET_NAME"]
-    prefix = os.environ["PROCESSING_BUCKET_INVENTORY_PREFIX"]
-    output_bucket = os.environ["OUTPUT_BUCKET"]
-    job_queue = os.environ["BATCH_QUEUE_NAME"]
-    job_definition_name = os.environ["BATCH_JOB_DEFINITION_NAME"]
-    max_active_jobs = int(os.environ["FEEDER_MAX_ACTIVE_JOBS"])
-    granule_submit_count = event["granule_submit_count"]
-
+def queue_feeder(
+    processing_bucket: str,
+    inventory_prefix: str,
+    output_bucket: str,
+    job_queue: str,
+    job_definition_name: str,
+    max_active_jobs: int,
+    granule_submit_count: int,
+) -> dict[str, Any]:
+    """Submit granule processing jobs to AWS Batch queue"""
     batch = AwsBatchClient(queue=job_queue, job_definition=job_definition_name)
     tracker = GranuleTrackerService(
-        bucket=bucket,
-        inventories_prefix=prefix,
+        bucket=processing_bucket,
+        inventories_prefix=inventory_prefix,
     )
 
     if not batch.active_jobs_below_threshold(max_active_jobs):
@@ -55,7 +47,6 @@ def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
         tracking, granule_submit_count
     )
 
-    # FIXME: add a time check and abandon early if going to timeout
     for i, granule_id in enumerate(granule_ids):
         processing_event = GranuleProcessingEvent(granule_id=granule_id, attempt=0)
         batch.submit_job(
@@ -64,3 +55,24 @@ def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
 
     tracker.update_tracking(updated_tracking)
     return updated_tracking.to_dict()
+
+
+def handler(event: dict[str, int], context: Any) -> dict[str, Any]:
+    """Queue feeder Lambda handler
+
+    The "event" payload contains,
+    ```
+    {
+        "granule_submit_count": 5000,
+    }
+    ```
+    """
+    return queue_feeder(
+        processing_bucket=os.environ["PROCESSING_BUCKET_NAME"],
+        inventory_prefix=os.environ["PROCESSING_BUCKET_INVENTORY_PREFIX"],
+        output_bucket=os.environ["OUTPUT_BUCKET"],
+        job_queue=os.environ["BATCH_QUEUE_NAME"],
+        job_definition_name=os.environ["BATCH_JOB_DEFINITION_NAME"],
+        max_active_jobs=int(os.environ["FEEDER_MAX_ACTIVE_JOBS"]),
+        granule_submit_count=event["granule_submit_count"],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,16 @@ def bucket(s3: S3Client, monkeypatch: pytest.MonkeyPatch) -> str:
     return "foo"
 
 
+@pytest.fixture
+def output_bucket(s3: S3Client, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Create our output bucket, returning bucket name and setting envvar"""
+    s3.create_bucket(
+        Bucket="outputs", CreateBucketConfiguration={"LocationConstraint": "us-west-2"}
+    )
+    monkeypatch.setenv("OUTPUT_BUCKET", "output")
+    return "output"
+
+
 # ==============================================================================
 # SQS
 @pytest.fixture

--- a/tests/test_queue_feeder.py
+++ b/tests/test_queue_feeder.py
@@ -56,6 +56,7 @@ def mocked_submit_job() -> Iterator[MagicMock]:
 
 def test_queue_feeder_handler(
     bucket: str,
+    output_bucket: str,
     local_inventory: Path,
     mocked_list_inventories: MagicMock,
     mocked_active_jobs_below_threshold: MagicMock,
@@ -79,6 +80,7 @@ def test_queue_feeder_handler(
 
 def test_queue_feeder_handler_too_many_jobs(
     bucket: str,
+    output_bucket: str,
     local_inventory: Path,
     mocked_list_inventories: MagicMock,
     mocked_submit_job: MagicMock,
@@ -105,6 +107,7 @@ def test_queue_feeder_handler_too_many_jobs(
 
 def test_queue_feeder_handler_granules_all_done(
     bucket: str,
+    output_bucket: str,
     local_inventory: Path,
     granule_tracker_service: GranuleTrackerService,
     mocked_active_jobs_below_threshold: MagicMock,


### PR DESCRIPTION
## What I am changing

This PR includes a few fixes I caught when integrating with the `hls-vi-historical` container (see "how I did it")

## How I did it

* Fixed missing `OUTPUT_BUCKET` envvar in container environment.
    * We override the container envvars when submitting a job, so I added this at the `SubmitJob` action level instead of for the `JobDefinition` (because the jobdef is overriden)
* Fixed missing ECR permissions for job execution role
* Define the "task role" that will have things like bucket read/write permissions separate from  the "execution" role. In the first iteration I forgot that we need both
* Add a generous upper limit for our job timeout so it can't run forever
* Ensure the job propagates resource tags into the ECS tasks running the job (e.g., for cost tracking)

## How you can test it

Absent an integration test stack, this is best tested manually in our dev environment. Alas the entire container can't be tested yet because we're having issues accessing the LPDAAC bucket (but that's another story...).
