### PR TITLE
feat: job requeuer

### DIFF
--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -377,8 +377,9 @@ class HlsViStack(Stack):
             memory_size=256,
             timeout=Duration.minutes(1),
             environment={
-                "PROCESSING_BUCKET_NAME": self.processing_bucket.bucket_name,
+                "OUTPUT_BUCKET": settings.OUTPUT_BUCKET_NAME,
                 "BATCH_QUEUE_NAME": self.batch_infra.queue.job_queue_name,
+                "BATCH_JOB_DEFINITION_NAME": self.processing_job.job_def.job_definition_name,
             },
             bundling=aws_lambda_python.BundlingOptions(
                 command_hooks=UvHooks(),

--- a/scripts/format
+++ b/scripts/format
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+uv run ruff check --fix
 uv run ruff format

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 uv run ruff check
+uv run ruff format --check

--- a/src/common/aws_batch.py
+++ b/src/common/aws_batch.py
@@ -117,7 +117,10 @@ class AwsBatchClient:
         return job_count < threshold
 
     def submit_job(
-        self, event: GranuleProcessingEvent, output_bucket: str, force_fail: bool
+        self,
+        event: GranuleProcessingEvent,
+        output_bucket: str,
+        force_fail: bool = False,
     ) -> str:
         """Submit granule processing event to queue, returning job ID"""
         container_overrides: ContainerOverridesTypeDef = {

--- a/src/job_requeuer/handler.py
+++ b/src/job_requeuer/handler.py
@@ -38,11 +38,11 @@ def job_requeuer(
         next_attempt = failed_event.new_attempt()
 
         logger.info(f"Submitting job for {next_attempt}")
-        resp = batch.submit_job(
+        job_id = batch.submit_job(
             event=next_attempt,
             output_bucket=output_bucket,
         )
-        jobs.append(resp["jobId"])
+        jobs.append(job_id)
     return jobs
 
 
@@ -68,4 +68,5 @@ def handler(event: SQSEvent, context: Context) -> list[str]:
         job_queue=job_queue,
         job_definition_name=job_definition_name,
         output_bucket=output_bucket,
+        event=event,
     )

--- a/src/job_requeuer/handler.py
+++ b/src/job_requeuer/handler.py
@@ -1,9 +1,55 @@
 """HLS-VI historical processing job requeuer."""
 
-from typing import Any
+from __future__ import annotations
 
-from common import GranuleProcessingEvent  # noqa: F401
+import json
+import logging
+import os
+from typing import TYPE_CHECKING
+
+from common import (
+    AwsBatchClient,
+    GranuleProcessingEvent,
+)
+
+if TYPE_CHECKING:
+    from aws_lambda_typing.context import Context
+    from aws_lambda_typing.events import SQSEvent
+
+logger = logging.getLogger(__name__)
+if logger.hasHandlers():
+    logger.setLevel(logging.INFO)
+else:
+    logging.basicConfig(level=logging.INFO)
 
 
-def handler(event: dict[str, str], context: Any) -> None:
-    print(f"Received event {event}")
+def handler(event: SQSEvent, context: Context) -> None:
+    """Resubmit failed processing events that can be retried
+
+    This Lambda is fed by a SQS queue, so the event payload looks like,
+    https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#example-standard-queue-message-event
+
+    The body of each event looks like,
+    ```
+    {
+        "GRANULE_ID": "HLS.S30.T01GEL.2019059T213751.v2.0",
+        "ATTEMPT": 0
+    }
+    ```
+    """
+    job_queue = os.environ["BATCH_QUEUE_NAME"]
+    job_definition_name = os.environ["BATCH_JOB_DEFINITION_NAME"]
+    output_bucket = os.environ["OUTPUT_BUCKET"]
+
+    logger.info(f"Received event {event}")
+    for record in event["Records"]:
+        failed_event = GranuleProcessingEvent(**json.loads(record["body"]))
+        next_attempt = failed_event.new_attempt()
+
+        batch = AwsBatchClient(queue=job_queue, job_definition=job_definition_name)
+
+        logger.info(f"Submitting job for {next_attempt}")
+        batch.submit_job(
+            event=next_attempt,
+            output_bucket=output_bucket,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 from typing import Iterator, cast
+from unittest.mock import MagicMock, patch
 
 import boto3
 import pandas as pd
@@ -12,7 +13,7 @@ from mypy_boto3_batch.type_defs import JobDetailTypeDef
 from mypy_boto3_s3 import S3Client
 from mypy_boto3_sqs import SQSClient
 
-from common.aws_batch import JobChangeEvent
+from common.aws_batch import AwsBatchClient, JobChangeEvent
 from common.granule_tracker import GranuleTrackerService
 from common.models import GranuleId
 
@@ -238,3 +239,14 @@ def s3_inventory(local_inventory: Path, bucket: str, s3: S3Client) -> str:
         Key=key,
     )
     return f"s3://{bucket}/{key}"
+
+
+# ===== AwsBatchClient
+@pytest.fixture
+def mocked_batch_client_submit_job() -> Iterator[MagicMock]:
+    with patch.object(
+        AwsBatchClient,
+        "submit_job",
+        return_value={"jobId": "foo-job-id"},
+    ) as mock:
+        yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,6 +247,6 @@ def mocked_batch_client_submit_job() -> Iterator[MagicMock]:
     with patch.object(
         AwsBatchClient,
         "submit_job",
-        return_value={"jobId": "foo-job-id"},
+        return_value="foo-job-id",
     ) as mock:
         yield mock

--- a/tests/test_queue_feeder.py
+++ b/tests/test_queue_feeder.py
@@ -44,23 +44,13 @@ def mocked_active_jobs_below_threshold(
         yield mock
 
 
-@pytest.fixture
-def mocked_submit_job() -> Iterator[MagicMock]:
-    with patch.object(
-        AwsBatchClient,
-        "submit_job",
-        return_value={"jobId": "foo-job-id"},
-    ) as mock:
-        yield mock
-
-
 def test_queue_feeder(
     bucket: str,
     output_bucket: str,
     local_inventory: Path,
     mocked_list_inventories: MagicMock,
     mocked_active_jobs_below_threshold: MagicMock,
-    mocked_submit_job: MagicMock,
+    mocked_batch_client_submit_job: MagicMock,
     batch_queue_name: str,
     batch_job_definition: str,
     max_active_jobs: int,
@@ -80,7 +70,7 @@ def test_queue_feeder(
 
     mocked_list_inventories.assert_called_once()
     mocked_active_jobs_below_threshold.assert_called_once()
-    assert mocked_submit_job.call_count == 2
+    assert mocked_batch_client_submit_job.call_count == 2
 
 
 def test_queue_feeder_handler_too_many_jobs(
@@ -88,7 +78,7 @@ def test_queue_feeder_handler_too_many_jobs(
     output_bucket: str,
     local_inventory: Path,
     mocked_list_inventories: MagicMock,
-    mocked_submit_job: MagicMock,
+    mocked_batch_client_submit_job: MagicMock,
     batch_queue_name: str,
     batch_job_definition: str,
     max_active_jobs: int,
@@ -112,7 +102,7 @@ def test_queue_feeder_handler_too_many_jobs(
     assert noop == {}
     mocked_active_jobs_below_threshold.assert_called()
     mocked_list_inventories.assert_not_called()
-    mocked_submit_job.assert_not_called()
+    mocked_batch_client_submit_job.assert_not_called()
 
 
 def test_queue_feeder_handler_granules_all_done(
@@ -121,7 +111,7 @@ def test_queue_feeder_handler_granules_all_done(
     local_inventory: Path,
     granule_tracker_service: GranuleTrackerService,
     mocked_active_jobs_below_threshold: MagicMock,
-    mocked_submit_job: MagicMock,
+    mocked_batch_client_submit_job: MagicMock,
     batch_queue_name: str,
     batch_job_definition: str,
     max_active_jobs: int,
@@ -155,4 +145,4 @@ def test_queue_feeder_handler_granules_all_done(
 
     mocked_list_inventories.assert_called_once()
     mocked_active_jobs_below_threshold.assert_called_once()
-    mocked_submit_job.assert_not_called()
+    mocked_batch_client_submit_job.assert_not_called()

--- a/tests/test_requeuer.py
+++ b/tests/test_requeuer.py
@@ -19,10 +19,10 @@ def test_requeuer_many(
         "HLS.S30.T42WOW.2023321T214901.v2.0": 2,
     }
     job_ids = job_requeuer(
-        "queue",
-        "job-def",
-        bucket,
-        SQSEvent(
+        job_queue="queue",
+        job_definition_name="job-def",
+        output_bucket=bucket,
+        event=SQSEvent(
             Records=[
                 {"body": json.dumps({"granule_id": granule_id, "attempt": attempt})}
                 for granule_id, attempt in granule_attempts.items()

--- a/tests/test_requeuer.py
+++ b/tests/test_requeuer.py
@@ -1,5 +1,36 @@
 """Tests for `requeuer` Lambda"""
 
+import json
+from unittest.mock import MagicMock
 
-def test_placeholder() -> None:
-    assert True
+from aws_lambda_typing.events import SQSEvent
+
+from job_requeuer.handler import job_requeuer
+
+
+def test_requeuer_many(
+    bucket: str,
+    mocked_batch_client_submit_job: MagicMock,
+) -> None:
+    """Test resubmitting several jobs from SQS queue"""
+    granule_attempts = {
+        "HLS.S30.T01GBH.2023051T214901.v2.0": 0,
+        "HLS.S30.T09ASD.2023123T214901.v2.0": 1,
+        "HLS.S30.T42WOW.2023321T214901.v2.0": 2,
+    }
+    job_ids = job_requeuer(
+        "queue",
+        "job-def",
+        bucket,
+        SQSEvent(
+            Records=[
+                {"body": json.dumps({"granule_id": granule_id, "attempt": attempt})}
+                for granule_id, attempt in granule_attempts.items()
+            ]
+        ),
+    )
+    assert len(job_ids) == len(granule_attempts)
+    for call in mocked_batch_client_submit_job.mock_calls:
+        assert call.kwargs["output_bucket"] == bucket
+        event = call.kwargs["event"]
+        assert event.attempt == granule_attempts[event.granule_id] + 1


### PR DESCRIPTION
## What I am changing

This PR adds the "job requeuer" that re-submits work from our "retryable queue" back into the AWS Batch cluster.

## How I did it

* Added "job requeuer" implementation
* Refactored mock on `AwsBachClient.submit_job` into `conftest.py` for use in 2 places
* Added happy path test for requeuer
* Fix format/lint scripts
* Fixed for using a public image that isn't on ECR, which therefore doesn't need IAM permissions (and doesn't have an ARN)

## How you can test it

```
scripts/test
```
