### PR TITLE
feat: Athena as granule processing event logs DB

### DIFF
--- a/cdk/hls_constructs/__init__.py
+++ b/cdk/hls_constructs/__init__.py
@@ -1,7 +1,9 @@
+from .athena_logs_database import AthenaLogsDatabase
 from .aws_batch_infra import BatchInfra
 from .aws_batch_job import BatchJob
 
 __all__ = [
+    "AthenaLogsDatabase",
     "BatchInfra",
     "BatchJob",
 ]

--- a/cdk/hls_constructs/athena_logs_database.py
+++ b/cdk/hls_constructs/athena_logs_database.py
@@ -172,7 +172,7 @@ class AthenaLogsDatabase(Construct):
             try(splits[3]) AS sensor,
             try(date_parse(splits[4], '%Y-%m-%d')) AS acquisition_date,
             try(splits[5]) AS granule_id,
-            try(cast(split_part(splits[6], '.', 2) AS INTEGER)) AS attempt,
+            try(cast(split_part(splits[6], '.', 2) AS INT)) AS attempt,
             last_modified_date
         FROM nested
         """
@@ -201,7 +201,7 @@ class AthenaLogsDatabase(Construct):
             aws_glue.CfnTable.ColumnProperty(
                 name="attempt",
                 comment="Attempt.",
-                type="INTEGER",
+                type="int",
             ),
             aws_glue.CfnTable.ColumnProperty(
                 name="last_modified_date",

--- a/cdk/hls_constructs/athena_logs_database.py
+++ b/cdk/hls_constructs/athena_logs_database.py
@@ -1,0 +1,254 @@
+import base64
+import datetime as dt
+import json
+from typing import Any
+
+from aws_cdk import Aws, RemovalPolicy, aws_glue
+from constructs import Construct
+
+
+def athena_type_to_presto(athena_type: str) -> str:
+    """Convert Athena column types to Presto types
+
+    This only supports a relevant subset of types. See also:
+    https://docs.aws.amazon.com/athena/latest/ug/data-types.html
+    """
+    lowered = athena_type.lower()
+    return {
+        "string": "varchar",
+        "struct": "row",
+        "float": "real",
+        "binary": "varbinary",
+    }.get(lowered, lowered)
+
+
+class AthenaLogsDatabase(Construct):
+    """Athena table for querying granule processing event logs"""
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        *,
+        database_name: str,
+        table_datetime_start: dt.datetime,
+        logs_s3_inventory_location_s3path: str,
+        logs_s3_inventory_table_name: str,
+        granule_processing_events_view_name: str,
+        work_group_name: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.database = aws_glue.CfnDatabase(
+            self,
+            "Database",
+            catalog_id=Aws.ACCOUNT_ID,
+            database_input={
+                "name": database_name,
+            },
+        )
+        self.s3_inventory_table = self._create_s3_inventory_table(
+            database=self.database,
+            table_datetime_start=table_datetime_start,
+            logs_s3_inventory_table_name=logs_s3_inventory_table_name,
+            logs_s3_inventory_location_s3path=logs_s3_inventory_location_s3path,
+        )
+        self.granule_processing_events_view = (
+            self._create_granule_processing_events_view(
+                database=self.database,
+                logs_s3_inventory_table=self.s3_inventory_table,
+                granule_processing_events_view_name=granule_processing_events_view_name,
+            )
+        )
+
+    def _create_s3_inventory_table(
+        self,
+        *,
+        database: aws_glue.CfnDatabase,
+        table_datetime_start: dt.datetime,
+        logs_s3_inventory_table_name: str,
+        logs_s3_inventory_location_s3path: str,
+    ) -> aws_glue.CfnTable:
+        """Create a Glue table for the S3 inventory reports"""
+        table_datetime_start_str = table_datetime_start.strftime("%Y-%m-%d-%H-%M")
+        table = aws_glue.CfnTable(
+            self,
+            "S3InventoryTable",
+            catalog_id=Aws.ACCOUNT_ID,
+            database_name=self.database.database_input.name,
+            table_input=aws_glue.CfnTable.TableInputProperty(
+                name=logs_s3_inventory_table_name,
+                table_type="EXTERNAL_TABLE",
+                parameters={
+                    "projection.dt.range": f"{table_datetime_start_str},NOW",
+                    "projection.dt.interval.unit": "HOURS",
+                    "EXTERNAL": "TRUE",
+                    "projection.dt.type": "date",
+                    "projection.enabled": "true",
+                    "projection.dt.interval": "1",
+                    "projection.dt.format": "yyyy-MM-dd-HH-mm",
+                },
+                partition_keys=[
+                    aws_glue.CfnTable.ColumnProperty(
+                        name="dt",
+                        comment="Report date",
+                        type="String",
+                    ),
+                ],
+                storage_descriptor=aws_glue.CfnTable.StorageDescriptorProperty(
+                    columns=[
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="bucket",
+                            comment="The name of the bucket that the inventory is for.",
+                            type="String",
+                        ),
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="key",
+                            comment="The object key name (or key) that uniquely identifies the object in the bucket.",
+                            type="String",
+                        ),
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="version_id",
+                            comment="The object version ID.",
+                            type="String",
+                        ),
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="is_latest",
+                            comment="Set to True if the object is the current version of the object.",
+                            type="boolean",
+                        ),
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="is_delete_marker",
+                            comment="Set to True if the object is a delete marker.",
+                            type="boolean",
+                        ),
+                        aws_glue.CfnTable.ColumnProperty(
+                            name="last_modified_date",
+                            comment="The object creation date or the last modified date, whichever is the latest.",
+                            type="timestamp",
+                        ),
+                    ],
+                    location=logs_s3_inventory_location_s3path,
+                    input_format="org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat",
+                    output_format="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                    serde_info=aws_glue.CfnTable.SerdeInfoProperty(
+                        serialization_library="org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+                        parameters={
+                            "serialization.format": "1",
+                        },
+                    ),
+                ),
+            ),
+        )
+        table.apply_removal_policy(RemovalPolicy.DESTROY)
+        table.add_depends_on(self.database)
+        return table
+
+    def _create_granule_processing_events_view(
+        self,
+        *,
+        database: aws_glue.CfnDatabase,
+        logs_s3_inventory_table: aws_glue.CfnTable,
+        granule_processing_events_view_name: str,
+    ) -> aws_glue.CfnTable:
+        """Create a view for granule processing events logs"""
+        sql = f"""WITH latest AS (
+            SELECT *
+            FROM {logs_s3_inventory_table.table_input.name}
+            WHERE
+                dt = (SELECT min(dt) from logs_s3_inventories)
+                AND is_latest
+                AND NOT is_delete_marker
+        ),
+        nested AS (
+            SELECT
+                split(key, '/') as splits,
+                last_modified_date
+            FROM latest
+        )
+        SELECT
+            try(splits[2]) AS status,
+            try(splits[3]) AS sensor,
+            try(date_parse(splits[4], '%Y-%m-%d')) AS acquisition_date,
+            try(splits[5]) AS granule_id,
+            try(cast(split_part(splits[6], '.', 2) AS INTEGER)) AS attempt,
+            last_modified_date
+        FROM nested
+        """
+
+        columns = [
+            aws_glue.CfnTable.ColumnProperty(
+                name="status",
+                comment="The processing event status (failed, success).",
+                type="String",
+            ),
+            aws_glue.CfnTable.ColumnProperty(
+                name="sensor",
+                comment="The sensor (L30, S30).",
+                type="String",
+            ),
+            aws_glue.CfnTable.ColumnProperty(
+                name="acquisition_date",
+                comment="The acquisition date.",
+                type="timestamp",
+            ),
+            aws_glue.CfnTable.ColumnProperty(
+                name="granule_id",
+                comment="HLS granule ID.",
+                type="String",
+            ),
+            aws_glue.CfnTable.ColumnProperty(
+                name="attempt",
+                comment="Attempt.",
+                type="INTEGER",
+            ),
+            aws_glue.CfnTable.ColumnProperty(
+                name="last_modified_date",
+                comment="The event log's creation date or the last modified date, whichever is the latest.",
+                type="timestamp",
+            ),
+        ]
+
+        view_specification = {
+            "originalSql": sql,
+            "catalog": Aws.ACCOUNT_ID,
+            "schema": self.database.database_input.name,
+            "columns": [
+                {"name": column.name, "type": athena_type_to_presto(column.type)}
+                for column in columns
+            ],
+        }
+
+        sql_b64 = base64.b64encode(
+            json.dumps(view_specification).encode("utf-8")
+        ).decode("utf-8")
+
+        view = aws_glue.CfnTable(
+            self,
+            "GranuleProcessingEventsView",
+            catalog_id=Aws.ACCOUNT_ID,
+            database_name=self.database.database_input.name,
+            table_input=aws_glue.CfnTable.TableInputProperty(
+                name=granule_processing_events_view_name,
+                table_type="VIRTUAL_VIEW",
+                parameters={"presto_view": "true", "comment": "Presto View"},
+                partition_keys=[
+                    aws_glue.CfnTable.ColumnProperty(
+                        name="dt",
+                        comment="Report date",
+                        type="String",
+                    ),
+                ],
+                storage_descriptor=aws_glue.CfnTable.StorageDescriptorProperty(
+                    columns=columns,
+                    input_format="org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat",
+                    output_format="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                ),
+                view_original_text=f"/* Presto View: {sql_b64} */",
+                view_expanded_text="/* Presto View */",
+            ),
+        )
+        view.apply_removal_policy(RemovalPolicy.DESTROY)
+        view.add_depends_on(logs_s3_inventory_table)
+        return view

--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -14,6 +14,7 @@ class BatchInfra(Construct):
         *,
         vpc: aws_ec2.IVpc,
         max_vcpu: int,
+        base_name: str,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -35,11 +36,13 @@ class BatchInfra(Construct):
                 subnet_type=aws_ec2.SubnetType.PRIVATE_ISOLATED,
             ),
             vpc=vpc,
+            compute_environment_name=f"{base_name}-compute-environment",
         )
 
         self.queue = aws_batch.JobQueue(
             self,
             "JobQueue",
+            job_queue_name=f"{base_name}-job-queue",
         )
         self.queue.add_compute_environment(self.compute_environment, 1)
 

--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from aws_cdk import CfnOutput, aws_batch, aws_ec2
+from aws_cdk import CfnOutput, aws_batch as batch, aws_ec2 as ec2
 from constructs import Construct
 
 
@@ -12,34 +12,34 @@ class BatchInfra(Construct):
         scope: Construct,
         construct_id: str,
         *,
-        vpc: aws_ec2.IVpc,
+        vpc: ec2.IVpc,
         max_vcpu: int,
         base_name: str,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        ecs_machine_image = aws_batch.EcsMachineImage(
-            image=aws_ec2.MachineImage.from_ssm_parameter("/mcp/amis/aml2-ecs"),
-            image_type=aws_batch.EcsMachineImageType.ECS_AL2,
+        ecs_machine_image = batch.EcsMachineImage(
+            image=ec2.MachineImage.from_ssm_parameter("/mcp/amis/aml2-ecs"),
+            image_type=batch.EcsMachineImageType.ECS_AL2,
         )
 
-        self.compute_environment = aws_batch.ManagedEc2EcsComputeEnvironment(
+        self.compute_environment = batch.ManagedEc2EcsComputeEnvironment(
             self,
             "ComputeEnvironment",
-            allocation_strategy=aws_batch.AllocationStrategy.SPOT_CAPACITY_OPTIMIZED,
+            allocation_strategy=batch.AllocationStrategy.SPOT_CAPACITY_OPTIMIZED,
             images=[ecs_machine_image],
             spot=True,
             minv_cpus=0,
             maxv_cpus=max_vcpu,
-            vpc_subnets=aws_ec2.SubnetSelection(
-                subnet_type=aws_ec2.SubnetType.PRIVATE_ISOLATED,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_ISOLATED,
             ),
             vpc=vpc,
             compute_environment_name=f"{base_name}-compute-environment",
         )
 
-        self.queue = aws_batch.JobQueue(
+        self.queue = batch.JobQueue(
             self,
             "JobQueue",
             job_queue_name=f"{base_name}-job-queue",

--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -88,3 +88,9 @@ class StackSettings(BaseSettings):
     JOB_FAILURE_DLQ_NAME: str
     # Give up requeueing after N attempts
     JOB_RETRY_MAX_ATTEMPTS: int = 3
+
+    # ----- Logs inventory Athena database
+    ATHENA_LOGS_DATABASE_NAME: str
+    ATHENA_LOGS_S3_INVENTORY_TABLE_START_DATETIME: dt.datetime
+    ATHENA_LOGS_S3_INVENTORY_TABLE_NAME: str = "logs_s3_inventories"
+    ATHENA_LOGS_GRANULE_PROCESSING_EVENTS_VIEW_NAME: str = "granule_processing_events"

--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -1,6 +1,15 @@
-from typing import Literal
+import datetime as dt
+from typing import Annotated, Any, Literal
 
+from pydantic import BeforeValidator
 from pydantic_settings import BaseSettings
+
+
+def include_trailing_slash(value: Any) -> Any:
+    """Make sure the value includes a trailing slash if str"""
+    if isinstance(value, str):
+        return value.rstrip("/") + "/"
+    return value
 
 
 class StackSettings(BaseSettings):
@@ -21,13 +30,19 @@ class StackSettings(BaseSettings):
 
     # ----- Buckets
     # Job processing bucket for state (inventories, failures, etc)
-    PROCESSING_BUCKET_NAME: str
+    PROCESSING_BUCKET_NAME: Annotated[str, BeforeValidator(include_trailing_slash)]
     # LPDAAC granule inventories prefix
-    PROCESSING_BUCKET_INVENTORY_PREFIX: str = "inventories"
+    PROCESSING_BUCKET_INVENTORY_PREFIX: Annotated[
+        str, BeforeValidator(include_trailing_slash)
+    ] = "inventories/"
     # Granule processing event logs prefix
-    PROCESSING_BUCKET_LOG_PREFIX: str = "logs"
+    PROCESSING_BUCKET_LOG_PREFIX: Annotated[
+        str, BeforeValidator(include_trailing_slash)
+    ] = "logs/"
     # Prefix for S3 inventories of granule processing logs
-    PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX: str = "logs-inventories"
+    PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX: Annotated[
+        str, BeforeValidator(include_trailing_slash)
+    ] = "logs-inventories/"
 
     # LDPAAC private input bucket (*tif files)
     LPDAAC_PROTECTED_BUCKET_NAME: str

--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -30,7 +30,7 @@ class StackSettings(BaseSettings):
 
     # ----- Buckets
     # Job processing bucket for state (inventories, failures, etc)
-    PROCESSING_BUCKET_NAME: Annotated[str, BeforeValidator(include_trailing_slash)]
+    PROCESSING_BUCKET_NAME: str
     # LPDAAC granule inventories prefix
     PROCESSING_BUCKET_INVENTORY_PREFIX: Annotated[
         str, BeforeValidator(include_trailing_slash)

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -191,7 +191,7 @@ class HlsViStack(Stack):
                 ],
                 resources=[
                     self.processing_bucket.arn_for_objects(
-                        f"{settings.PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX}/*"
+                        f"{settings.PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX}*"
                     ),
                 ],
                 principals=[
@@ -340,7 +340,7 @@ class HlsViStack(Stack):
         )
         self.processing_bucket.grant_read_write(
             self.inventory_converter_lambda,
-            objects_key_pattern=f"{settings.PROCESSING_BUCKET_INVENTORY_PREFIX}/*",
+            objects_key_pattern=f"{settings.PROCESSING_BUCKET_INVENTORY_PREFIX}*",
         )
 
         # ----------------------------------------------------------------------

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -213,6 +213,7 @@ class HlsViStack(Stack):
                 "hive",
             ]
         )
+
         self.athena_logs_database = AthenaLogsDatabase(
             self,
             "AthenaLogsDatabase",

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -8,17 +8,17 @@ from aws_cdk import (
     RemovalPolicy,
     Size,
     Stack,
-    aws_batch,
-    aws_ec2,
-    aws_events,
-    aws_events_targets,
-    aws_iam,
-    aws_lambda,
-    aws_s3,
-    aws_secretsmanager,
-    aws_sqs,
+    aws_batch as batch,
+    aws_ec2 as ec2,
+    aws_events as events,
+    aws_events_targets as events_targets,
+    aws_iam as iam,
+    aws_lambda as lambda_,
+    aws_lambda_python_alpha as lambda_python,
+    aws_s3 as s3,
+    aws_secretsmanager as secretsmanager,
+    aws_sqs as sqs,
 )
-from aws_cdk import aws_lambda_python_alpha as aws_lambda_python
 from constructs import Construct
 from hls_constructs import AthenaLogsDatabase, BatchInfra, BatchJob
 from settings import StackSettings
@@ -54,7 +54,7 @@ UV_DOCKER_VOLUMES = [
 ]
 
 
-@jsii.implements(aws_lambda_python.ICommandHooks)
+@jsii.implements(lambda_python.ICommandHooks)
 class UvHooks:
     """Build hooks to setup UV and export a requirements.txt for building
 
@@ -98,39 +98,39 @@ class HlsViStack(Stack):
         super().__init__(scope, stack_id, **kwargs)
 
         # Apply IAM permission boundary to entire stack
-        boundary = aws_iam.ManagedPolicy.from_managed_policy_arn(
+        boundary = iam.ManagedPolicy.from_managed_policy_arn(
             self,
             "PermissionBoundary",
             settings.MCP_IAM_PERMISSION_BOUNDARY_ARN,
         )
-        aws_iam.PermissionsBoundary.of(self).apply(boundary)
+        iam.PermissionsBoundary.of(self).apply(boundary)
 
         # ----------------------------------------------------------------------
         # Networking
         # ----------------------------------------------------------------------
-        self.vpc = aws_ec2.Vpc.from_lookup(self, "VPC", vpc_id=settings.VPC_ID)
+        self.vpc = ec2.Vpc.from_lookup(self, "VPC", vpc_id=settings.VPC_ID)
 
         # ----------------------------------------------------------------------
         # Buckets
         # ----------------------------------------------------------------------
-        self.lpdaac_protected_bucket = aws_s3.Bucket.from_bucket_name(
+        self.lpdaac_protected_bucket = s3.Bucket.from_bucket_name(
             self,
             "LpdaacProtectedBucket",
             bucket_name=settings.LPDAAC_PROTECTED_BUCKET_NAME,
         )
-        self.lpdaac_public_bucket = aws_s3.Bucket.from_bucket_name(
+        self.lpdaac_public_bucket = s3.Bucket.from_bucket_name(
             self,
             "LpdaacPublicBucket",
             bucket_name=settings.LPDAAC_PUBLIC_BUCKET_NAME,
         )
 
-        self.output_bucket = aws_s3.Bucket.from_bucket_name(
+        self.output_bucket = s3.Bucket.from_bucket_name(
             self,
             "OutputBucket",
             bucket_name=settings.OUTPUT_BUCKET_NAME,
         )
 
-        self.processing_bucket = aws_s3.Bucket(
+        self.processing_bucket = s3.Bucket(
             self,
             "ProcessingBucket",
             bucket_name=settings.PROCESSING_BUCKET_NAME,
@@ -139,22 +139,22 @@ class HlsViStack(Stack):
                 # Setting expired_object_delete_marker cannot be done within a
                 # lifecycle rule that also specifies expiration, expiration_date, or
                 # tag_filters.
-                aws_s3.LifecycleRule(expired_object_delete_marker=True),
-                aws_s3.LifecycleRule(
+                s3.LifecycleRule(expired_object_delete_marker=True),
+                s3.LifecycleRule(
                     abort_incomplete_multipart_upload_after=Duration.days(1),
                     noncurrent_version_expiration=Duration.days(1),
                 ),
             ],
-            encryption=aws_s3.BucketEncryption.S3_MANAGED,
+            encryption=s3.BucketEncryption.S3_MANAGED,
         )
 
         bucket_envvars = {
             "OUTPUT_BUCKET": settings.OUTPUT_BUCKET_NAME,
         }
 
-        self.debug_bucket: aws_s3.IBucket | None
+        self.debug_bucket: s3.IBucket | None
         if settings.DEBUG_BUCKET_NAME:
-            self.debug_bucket = aws_s3.Bucket.from_bucket_name(
+            self.debug_bucket = s3.Bucket.from_bucket_name(
                 self,
                 "DebugBucket",
                 bucket_name=settings.DEBUG_BUCKET_NAME,
@@ -169,15 +169,15 @@ class HlsViStack(Stack):
         inventory_id = "granule_processing_logs"
         self.processing_bucket.add_inventory(
             enabled=True,
-            destination=aws_s3.InventoryDestination(
-                bucket=aws_s3.Bucket.from_bucket_name(
+            destination=s3.InventoryDestination(
+                bucket=s3.Bucket.from_bucket_name(
                     self, "ProcessingBucketRef", settings.PROCESSING_BUCKET_NAME
                 ),
                 prefix=settings.PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX,
             ),
             inventory_id=inventory_id,
-            format=aws_s3.InventoryFormat.PARQUET,
-            frequency=aws_s3.InventoryFrequency.DAILY,
+            format=s3.InventoryFormat.PARQUET,
+            frequency=s3.InventoryFrequency.DAILY,
             objects_prefix=settings.PROCESSING_BUCKET_LOG_PREFIX,
             optional_fields=["LastModifiedDate"],
         )
@@ -188,7 +188,7 @@ class HlsViStack(Stack):
 
         # S3 service also needs permissions to push to the bucket
         self.processing_bucket.add_to_resource_policy(
-            aws_iam.PolicyStatement(
+            iam.PolicyStatement(
                 actions=[
                     "s3:PutObject",
                 ],
@@ -198,9 +198,9 @@ class HlsViStack(Stack):
                     ),
                 ],
                 principals=[
-                    aws_iam.ServicePrincipal("s3.amazonaws.com"),
+                    iam.ServicePrincipal("s3.amazonaws.com"),
                 ],
-                effect=aws_iam.Effect.ALLOW,
+                effect=iam.Effect.ALLOW,
             )
         )
 
@@ -228,13 +228,13 @@ class HlsViStack(Stack):
         # Earthdata Login (EDL) S3 credential rotator
         # ----------------------------------------------------------------------
         # NB - this secret must be created by developer team
-        self.edl_user_pass_credentials = aws_secretsmanager.Secret.from_secret_name_v2(
+        self.edl_user_pass_credentials = secretsmanager.Secret.from_secret_name_v2(
             self,
             id="EdlUserPassCredentials",
             secret_name=f"hls-vi-historical-orchestration/{settings.STAGE}/edl-user-credentials",
         )
 
-        self.edl_s3_credentials = aws_secretsmanager.Secret(
+        self.edl_s3_credentials = secretsmanager.Secret(
             self,
             id="EdlS3Credentials",
             secret_name=f"hls-vi-historical-orchestration/{settings.STAGE}/edl-s3-credentials",
@@ -245,13 +245,13 @@ class HlsViStack(Stack):
         #   * ACCESS_KEY_ID
         #   * SECRET_ACCESS_KEY
         #   * SESSION_TOKEN
-        self.edl_credential_rotator = aws_lambda_python.PythonFunction(
+        self.edl_credential_rotator = lambda_python.PythonFunction(
             self,
             "EdlCredentialRotator",
             entry="src/edl_credential_rotator",
             index="handler.py",
             handler="handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=256,
             timeout=Duration.minutes(1),
             environment={
@@ -262,16 +262,16 @@ class HlsViStack(Stack):
         self.edl_user_pass_credentials.grant_read(self.edl_credential_rotator)
         self.edl_s3_credentials.grant_write(self.edl_credential_rotator)
 
-        self.edl_credential_rotator_schedule = aws_events.Rule(
+        self.edl_credential_rotator_schedule = events.Rule(
             self,
             "EdlCredentialRotatorSchedule",
-            schedule=aws_events.Schedule.rate(
+            schedule=events.Schedule.rate(
                 Duration.minutes(30),
             ),
         )
         if settings.SCHEDULE_LPDAAC_CREDS_ROTATION:
             self.edl_credential_rotator_schedule.add_target(
-                aws_events_targets.LambdaFunction(
+                events_targets.LambdaFunction(
                     handler=self.edl_credential_rotator,
                 )
             )
@@ -299,13 +299,13 @@ class HlsViStack(Stack):
             retry_attempts=settings.PROCESSING_JOB_RETRY_ATTEMPTS,
             log_group_name=settings.PROCESSING_LOG_GROUP_NAME,
             secrets={
-                "LPDAAC_SECRET_ACCESS_KEY": aws_batch.Secret.from_secrets_manager(
+                "LPDAAC_SECRET_ACCESS_KEY": batch.Secret.from_secrets_manager(
                     self.edl_s3_credentials, "SECRET_ACCESS_KEY"
                 ),
-                "LPDAAC_ACCESS_KEY_ID": aws_batch.Secret.from_secrets_manager(
+                "LPDAAC_ACCESS_KEY_ID": batch.Secret.from_secrets_manager(
                     self.edl_s3_credentials, "ACCESS_KEY_ID"
                 ),
-                "LPDAAC_SESSION_TOKEN": aws_batch.Secret.from_secrets_manager(
+                "LPDAAC_SESSION_TOKEN": batch.Secret.from_secrets_manager(
                     self.edl_s3_credentials, "SESSION_TOKEN"
                 ),
             },
@@ -322,20 +322,20 @@ class HlsViStack(Stack):
         # ----------------------------------------------------------------------
         # One-off inventory conversion Lambda
         # ----------------------------------------------------------------------
-        self.inventory_converter_lambda = aws_lambda_python.PythonFunction(
+        self.inventory_converter_lambda = lambda_python.PythonFunction(
             self,
             "InventoryConverterHandler",
             entry="src/",
             index="inventory_converter/handler.py",
             handler="handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=1024,
             timeout=Duration.minutes(10),
             environment={
                 "PROCESSING_BUCKET_NAME": self.processing_bucket.bucket_name,
                 "PROCESSING_BUCKET_INVENTORY_PREFIX": settings.PROCESSING_BUCKET_INVENTORY_PREFIX,
             },
-            bundling=aws_lambda_python.BundlingOptions(
+            bundling=lambda_python.BundlingOptions(
                 command_hooks=UvHooks(groups=["arrow"]),
                 asset_excludes=LAMBDA_EXCLUDE,
                 volumes=UV_DOCKER_VOLUMES,
@@ -350,13 +350,13 @@ class HlsViStack(Stack):
         # ----------------------------------------------------------------------
         # Queue feeder
         # ----------------------------------------------------------------------
-        self.queue_feeder_lambda = aws_lambda_python.PythonFunction(
+        self.queue_feeder_lambda = lambda_python.PythonFunction(
             self,
             "QueueFeederHandler",
             entry="src/",
             index="queue_feeder/handler.py",
             handler="handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=512,
             timeout=Duration.minutes(10),
             reserved_concurrent_executions=1,
@@ -368,7 +368,7 @@ class HlsViStack(Stack):
                 "BATCH_JOB_DEFINITION_NAME": self.processing_job.job_def.job_definition_name,
                 **bucket_envvars,
             },
-            bundling=aws_lambda_python.BundlingOptions(
+            bundling=lambda_python.BundlingOptions(
                 command_hooks=UvHooks(groups=["arrow"]),
                 asset_excludes=LAMBDA_EXCLUDE,
                 volumes=UV_DOCKER_VOLUMES,
@@ -382,8 +382,8 @@ class HlsViStack(Stack):
         # Ref: AWS Batch IAM actions/resources/conditions
         # https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsbatch.html
         self.queue_feeder_lambda.add_to_role_policy(
-            aws_iam.PolicyStatement(
-                effect=aws_iam.Effect.ALLOW,
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
                 resources=[
                     self.batch_infra.queue.job_queue_arn,
                     self.processing_job.job_def_arn_without_revision,
@@ -394,8 +394,8 @@ class HlsViStack(Stack):
             )
         )
         self.queue_feeder_lambda.add_to_role_policy(
-            aws_iam.PolicyStatement(
-                effect=aws_iam.Effect.ALLOW,
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
                 resources=["*"],
                 actions=[
                     "batch:ListJobs",
@@ -404,17 +404,17 @@ class HlsViStack(Stack):
         )
 
         # Schedule queue feeder
-        self.queue_feeder_schedule = aws_events.Rule(
+        self.queue_feeder_schedule = events.Rule(
             self,
             "QueueFeederSchedule",
-            schedule=aws_events.Schedule.rate(
+            schedule=events.Schedule.rate(
                 Duration.minutes(settings.FEEDER_EXECUTION_SCHEDULE_RATE_MINUTES),
             ),
         )
         if settings.SCHEDULE_QUEUE_FEEDER:
             self.queue_feeder_schedule.add_target(
-                aws_events_targets.LambdaFunction(
-                    event=aws_events.RuleTargetInput.from_object(
+                events_targets.LambdaFunction(
+                    event=events.RuleTargetInput.from_object(
                         {
                             "granule_submit_count": settings.FEEDER_GRANULE_SUBMIT_COUNT,
                         }
@@ -428,21 +428,21 @@ class HlsViStack(Stack):
         # Job monitor & retry system
         # ----------------------------------------------------------------------
         # Queue for job failures we need to investigate (bugs, repeat errors, etc)
-        self.job_failure_dlq = aws_sqs.Queue(
+        self.job_failure_dlq = sqs.Queue(
             self,
             "JobRetryFailureDLQ",
             queue_name=settings.JOB_FAILURE_DLQ_NAME,
             retention_period=Duration.days(14),
             enforce_ssl=True,
-            encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
+            encryption=sqs.QueueEncryption.SQS_MANAGED,
         )
 
         # Queue for failed AWS Batch processing jobs we want to requeue
-        self.job_retry_queue = aws_sqs.Queue(
+        self.job_retry_queue = sqs.Queue(
             self,
             "JobRetryFailureQueue",
             queue_name=settings.JOB_RETRY_QUEUE_NAME,
-            dead_letter_queue=aws_sqs.DeadLetterQueue(
+            dead_letter_queue=sqs.DeadLetterQueue(
                 queue=self.job_failure_dlq,
                 # Route to DLQ immediately if we can't process
                 max_receive_count=1,
@@ -450,16 +450,16 @@ class HlsViStack(Stack):
             retention_period=Duration.days(14),
             visibility_timeout=Duration.minutes(2),
             enforce_ssl=True,
-            encryption=aws_sqs.QueueEncryption.SQS_MANAGED,
+            encryption=sqs.QueueEncryption.SQS_MANAGED,
         )
 
-        self.job_monitor_lambda = aws_lambda_python.PythonFunction(
+        self.job_monitor_lambda = lambda_python.PythonFunction(
             self,
             "JobMonitorHandler",
             entry="src/",
             index="job_monitor/handler.py",
             handler="handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=256,
             timeout=Duration.minutes(1),
             environment={
@@ -472,7 +472,7 @@ class HlsViStack(Stack):
                     settings.PROCESSING_JOB_RETRY_ATTEMPTS
                 ),
             },
-            bundling=aws_lambda_python.BundlingOptions(
+            bundling=lambda_python.BundlingOptions(
                 command_hooks=UvHooks(),
                 asset_excludes=LAMBDA_EXCLUDE,
                 volumes=UV_DOCKER_VOLUMES,
@@ -487,10 +487,10 @@ class HlsViStack(Stack):
 
         # Events from AWS Batch "job state change events" in our processing queue
         # Ref: https://docs.aws.amazon.com/batch/latest/userguide/batch_job_events.html
-        self.processing_job_events_rule = aws_events.Rule(
+        self.processing_job_events_rule = events.Rule(
             self,
             "ProcessingJobEventsRule",
-            event_pattern=aws_events.EventPattern(
+            event_pattern=events.EventPattern(
                 source=["aws.batch"],
                 detail={
                     # only retry jobs from our queue and job definition that failed
@@ -505,7 +505,7 @@ class HlsViStack(Stack):
                 },
             ),
             targets=[
-                aws_events_targets.LambdaFunction(
+                events_targets.LambdaFunction(
                     handler=self.job_monitor_lambda,
                     retry_attempts=3,
                 )
@@ -515,13 +515,13 @@ class HlsViStack(Stack):
         # ----------------------------------------------------------------------
         # Requeuer
         # ----------------------------------------------------------------------
-        self.job_requeuer_lambda = aws_lambda_python.PythonFunction(
+        self.job_requeuer_lambda = lambda_python.PythonFunction(
             self,
             "JobRequeuerHandler",
             entry="src/",
             index="job_requeuer/handler.py",
             handler="handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
+            runtime=lambda_.Runtime.PYTHON_3_12,
             memory_size=256,
             timeout=Duration.minutes(1),
             environment={
@@ -529,7 +529,7 @@ class HlsViStack(Stack):
                 "BATCH_JOB_DEFINITION_NAME": self.processing_job.job_def.job_definition_name,
                 **bucket_envvars,
             },
-            bundling=aws_lambda_python.BundlingOptions(
+            bundling=lambda_python.BundlingOptions(
                 command_hooks=UvHooks(),
                 asset_excludes=LAMBDA_EXCLUDE,
                 volumes=UV_DOCKER_VOLUMES,
@@ -540,8 +540,8 @@ class HlsViStack(Stack):
             self.job_requeuer_lambda, objects_key_pattern="logs/*"
         )
         self.job_requeuer_lambda.add_to_role_policy(
-            aws_iam.PolicyStatement(
-                effect=aws_iam.Effect.ALLOW,
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
                 resources=[
                     self.batch_infra.queue.job_queue_arn,
                     self.processing_job.job_def_arn_without_revision,

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -259,6 +259,7 @@ class HlsViStack(Stack):
             "HLS-VI-Infra",
             vpc=self.vpc,
             max_vcpu=settings.BATCH_MAX_VCPU,
+            base_name=f"hls-vi-historical-orchestration-{settings.STAGE}",
         )
 
         # ----------------------------------------------------------------------

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -181,7 +181,10 @@ class HlsViStack(Stack):
             objects_prefix=settings.PROCESSING_BUCKET_LOG_PREFIX,
             optional_fields=["LastModifiedDate"],
         )
-        # FIXME: add lifecycle policy for inventory reports ~> 7 days
+        self.processing_bucket.add_lifecycle_rule(
+            prefix=settings.PROCESSING_BUCKET_LOGS_INVENTORY_PREFIX,
+            expiration=Duration.days(14),
+        )
 
         # S3 service also needs permissions to push to the bucket
         self.processing_bucket.add_to_resource_policy(

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -514,7 +514,7 @@ class HlsViStack(Stack):
         self.processing_bucket.grant_read_write(
             self.job_requeuer_lambda, objects_key_pattern="logs/*"
         )
-        self.queue_feeder_lambda.add_to_role_policy(
+        self.job_requeuer_lambda.add_to_role_policy(
             aws_iam.PolicyStatement(
                 effect=aws_iam.Effect.ALLOW,
                 resources=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ known-first-party = [
   "job_requeuer",
   "queue_feeder",
 ]
+combine-as-imports = true
 
 [tool.mypy]
 files = ["cdk", "src", "tests"]

--- a/src/job_requeuer/handler.py
+++ b/src/job_requeuer/handler.py
@@ -46,7 +46,7 @@ def job_requeuer(
     return jobs
 
 
-def handler(event: SQSEvent, context: Context) -> list[str]:
+def handler(event: SQSEvent, context: Context) -> dict[str, list[str]]:
     """Resubmit failed processing events that can be retried
 
     This Lambda is fed by a SQS queue, so the event payload looks like,

--- a/src/job_requeuer/handler.py
+++ b/src/job_requeuer/handler.py
@@ -65,9 +65,10 @@ def handler(event: SQSEvent, context: Context) -> list[str]:
     output_bucket = os.environ["OUTPUT_BUCKET"]
     debug_bucket = os.environ.get("DEBUG_BUCKET")
 
-    return job_requeuer(
+    job_requeuer(
         job_queue=job_queue,
         job_definition_name=job_definition_name,
         output_bucket=debug_bucket or output_bucket,
         event=event,
     )
+    return {"batchItemFailures": []}


### PR DESCRIPTION
## What I am changing

This PR adds 2 Glue tables (1 table + 1 view) for parsing our logs from the S3 inventories. It also contains a few fixes I noticed while debugging.

## How I did it

* Create new construct for Glue tables we can query via Athena
    * Created Glue table for our S3 inventories
    * Created a view on this inventory table to grab the latest report and parse the "key" into relevant columns
* Fixes,
    * Fixed S3 inventory prefix (forgot the trailing `/`, so it had inventoried more than just `logs/`)
    * S3 inventories should be auto-deleted after some time to keep bucket size small and Athena queries fast
    * Fixed policy statement applied to the wrong Lambda function
    * Use a human comprehensible name for our AWS Batch infrastructure
    * Fixed job requeuer handler so SQS<>Lambda integration deletes the messages appropriately. Previously we had returned some info about what jobs were resubmitted, and AWS interpreted this as failures. See the ["Success and failure conditions" on this page](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-batchfailurereporting) for more background.

## How you can test it

Not much change to function code
```
scripts/test
```
but I've deployed this to "dev" and have been able to query our inventories!