### PR TITLE
fix: allow parameterization of AMI, defaulting to AML2023

### DIFF
--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -58,7 +58,7 @@ class BatchInfra(Construct):
 
         # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id
         ec2_machine_image = ec2.MachineImage.resolve_ssm_parameter_at_launch(
-            "/mcp/amis/aml2-ecs",
+            "/mcp/amis/aml2023-ecs",
         )
         ecs_machine_image = batch.EcsMachineImage(
             image=ec2_machine_image,

--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -64,7 +64,7 @@ class BatchInfra(Construct):
         if "resolve:ssm:" in ami_id:
             # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id
             ec2_machine_image = ec2.MachineImage.resolve_ssm_parameter_at_launch(
-                ami_id.lstrip("resolve:ssm:")
+                ami_id.removeprefix("resolve:ssm:")
             )
         else:
             ec2_machine_image = ec2.MachineImage.lookup(name=ami_id)

--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -15,6 +15,7 @@ class BatchInfra(Construct):
         vpc: ec2.IVpc,
         instance_classes: list[str] | None,
         max_vcpu: int,
+        ami_id: str,
         stage: str,
         **kwargs: Any,
     ) -> None:
@@ -31,6 +32,10 @@ class BatchInfra(Construct):
             "optimal" instance classes.
         max_vcpu:
             Maximum number of CPUs in the ComputeEnvironment
+        ami_id:
+            AWS Batch Ec2 instance AMI identifier, OR name of SSM parameter that
+            references the AMI ID prefixed by `resolve:ssm` (e.g,
+            `resolve:ssm:/param-name`).
         stage:
             Environment or "stage" for resources used to help distinguish resources
             from this stack.
@@ -56,10 +61,13 @@ class BatchInfra(Construct):
             ec2.MultipartBody.from_user_data(command_user_data)
         )
 
-        # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id
-        ec2_machine_image = ec2.MachineImage.resolve_ssm_parameter_at_launch(
-            "/mcp/amis/aml2023-ecs",
-        )
+        if "resolve:ssm:" in ami_id:
+            # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-launch-template.html#use-an-ssm-parameter-instead-of-an-ami-id
+            ec2_machine_image = ec2.MachineImage.resolve_ssm_parameter_at_launch(
+                ami_id.lstrip("resolve:ssm:")
+            )
+        else:
+            ec2_machine_image = ec2.MachineImage.lookup(name=ami_id)
         ecs_machine_image = batch.EcsMachineImage(
             image=ec2_machine_image,
             image_type=batch.EcsMachineImageType.ECS_AL2,

--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -76,6 +76,10 @@ class StackSettings(BaseSettings):
     # Number of internal AWS Batch job retries
     PROCESSING_JOB_RETRY_ATTEMPTS: int = 3
 
+    # AWS Batch cluster reference to SSM parameter describing the AMI _or_ the AMI ID
+    # If using SSM to resolve the AMI ID, prefix with `resolve:ssm`.
+    MCP_AMI_ID: str = "resolve:ssm:/mcp/amis/aml2023-ecs"
+
     # Cluster instance classes
     BATCH_INSTANCE_CLASSES: list[str] = [
         "C4",

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -301,6 +301,7 @@ class HlsViStack(Stack):
             vpc=self.vpc,
             instance_classes=settings.BATCH_INSTANCE_CLASSES,
             max_vcpu=settings.BATCH_MAX_VCPU,
+            ami_id=settings.MCP_AMI_ID,
             stage=settings.STAGE,
         )
 

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -439,19 +439,19 @@ class HlsViStack(Stack):
             schedule=events.Schedule.rate(
                 Duration.minutes(settings.FEEDER_EXECUTION_SCHEDULE_RATE_MINUTES),
             ),
+            enabled=settings.SCHEDULE_QUEUE_FEEDER,
         )
-        if settings.SCHEDULE_QUEUE_FEEDER:
-            self.queue_feeder_schedule.add_target(
-                events_targets.LambdaFunction(
-                    event=events.RuleTargetInput.from_object(
-                        {
-                            "granule_submit_count": settings.FEEDER_GRANULE_SUBMIT_COUNT,
-                        }
-                    ),
-                    handler=self.queue_feeder_lambda,
-                    retry_attempts=3,
-                )
-            )
+        self.queue_feeder_schedule.add_target(
+            events_targets.LambdaFunction(
+                event=events.RuleTargetInput.from_object(
+                    {
+                        "granule_submit_count": settings.FEEDER_GRANULE_SUBMIT_COUNT,
+                    }
+                ),
+                handler=self.queue_feeder_lambda,
+                retry_attempts=3,
+            ),
+        )
 
         # ----------------------------------------------------------------------
         # Job monitor & retry system


### PR DESCRIPTION
## What I am changing

This PR adds support for defining the AMI we use for our Batch cluster via Github environment and updates to default to AML 2023, the successor to AML2.

This is intended to give us more control over our infrastructure without requiring code change for hypothetical events like,

* SSM references a bad / non-existing AMI (i.e., the motivating case for this PR)
* This lives on long enough that AML2023 is deprecated

## How I did it

* Add AMI_ID to settings
* Pipe AMI_ID from settings into Batch cluster construct
* Check if `resolve:ssm:` exists in AMI ID and do the right thing

## How you can test it

CDK diff