### PR TITLE
fix: don't queue retry if AWS Batch will retry the job

### DIFF
--- a/cdk/settings.py
+++ b/cdk/settings.py
@@ -70,7 +70,6 @@ class StackSettings(BaseSettings):
     # Job vCPU and memory limits
     PROCESSING_JOB_VCPU: int = 1
     PROCESSING_JOB_MEMORY_MB: int = 2_000
-    PROCESSING_JOB_MAX_DOWNLOAD_THREADS: int = 4
     # Custom log group (otherwise they'll land in the catch-all AWS Batch log group)
     PROCESSING_LOG_GROUP_NAME: str
     # Number of internal AWS Batch job retries
@@ -96,15 +95,12 @@ class StackSettings(BaseSettings):
     FEEDER_EXECUTION_SCHEDULE_RATE_MINUTES: int = 60
     FEEDER_MAX_ACTIVE_JOBS: int = 10_000
     FEEDER_GRANULE_SUBMIT_COUNT: int = 50  # 5_000
-    FEEDER_JOBS_PER_ARRAY_TASK: int = 1_000
 
     # ----- Job retry system
     # Send retryable failed AWS Batch jobs to this queue
     JOB_RETRY_QUEUE_NAME: str
     # Failed AWS Batch jobs go to a DLQ that can redrive to the retry queue
     JOB_FAILURE_DLQ_NAME: str
-    # Give up requeueing after N attempts
-    JOB_RETRY_MAX_ATTEMPTS: int = 3
 
     # ----- Logs inventory Athena database
     ATHENA_LOGS_DATABASE_NAME: str

--- a/cdk/stack.py
+++ b/cdk/stack.py
@@ -333,9 +333,6 @@ class HlsViStack(Stack):
             log_group_name=settings.PROCESSING_LOG_GROUP_NAME,
             environment={
                 "PYTHONUNBUFFERED": "TRUE",
-                "MAX_DOWNLOAD_THREADS": str(
-                    settings.PROCESSING_JOB_MAX_DOWNLOAD_THREADS
-                ),
             },
             secrets=secrets,
             stage=settings.STAGE,

--- a/src/common/aws_batch.py
+++ b/src/common/aws_batch.py
@@ -46,12 +46,18 @@ class JobDetails:
 
     @property
     def job_id(self) -> str:
+        """AWS Batch job identifier"""
         return self.detail["jobId"]
 
     @property
     def attempts(self) -> int:
-        """Return the number of attempts from this job"""
+        """The number of attempts from this job"""
         return len(self.detail.get("attempts", []))
+
+    @property
+    def max_attempts(self) -> int:
+        """Maximum number of attempts according to retry strategy"""
+        return self.detail["retryStrategy"]["attempts"]
 
     @property
     def exit_code(self) -> int | None:
@@ -75,10 +81,14 @@ class JobDetails:
         """Return the outcome of this job"""
         if self.exit_code == 0:
             return JobOutcome.SUCCESS
-        # Jobs that are killed by SPOT interruptions won't have an error code,
+
+        # Jobs that are killed by Spot interruptions won't have an error code,
         # but neither will jobs that are cancelled or terminated.
+        # Note that this behavior is coupled to the "retryStrategy" config for
+        # the deployed AWS Batch JobDefinition.
         if self.exit_code is None and self.status_reason.startswith("Host EC2"):
             return JobOutcome.FAILURE_RETRYABLE
+
         return JobOutcome.FAILURE_NONRETRYABLE
 
     def get_granule_event(self) -> GranuleProcessingEvent:

--- a/src/common/aws_batch.py
+++ b/src/common/aws_batch.py
@@ -50,14 +50,14 @@ class JobDetails:
         return self.detail["jobId"]
 
     @property
-    def attempts(self) -> int:
+    def job_attempts(self) -> int:
         """The number of attempts from this job"""
         return len(self.detail.get("attempts", []))
 
     @property
     def max_attempts(self) -> int:
         """Maximum number of attempts according to retry strategy"""
-        return self.detail["retryStrategy"]["attempts"]
+        return self.detail.get("retryStrategy", {}).get("attempts", 1)
 
     @property
     def exit_code(self) -> int | None:

--- a/src/job_monitor/handler.py
+++ b/src/job_monitor/handler.py
@@ -35,21 +35,38 @@ else:
 
 
 def job_monitor(
+    *,
+    job_change_event: JobChangeEvent,
     logs_bucket: str,
     logs_prefix: str,
     retry_queue_url: str,
     failure_dlq_url: str,
-    job_change_event: JobChangeEvent,
 ) -> None:
     """Handle job failure and success state change events
 
     All job outcomes (successes, failures, and retryable failures) are logged.
 
-    Retryable failures (e.g., SPOT interruptions) are re-routed to a queue for the
-    "requeuer" to pickup.
+    Retryable failures (e.g., Spot interruptions) are re-routed to a queue for the
+    "requeuer" to pickup when the failure is on the last attempt of the
+    JobDefinition's retry strategy.
 
     Non-retryable failures (non-zero exit codes) are routed to a DLQ for triage
     and redriving into the "requeuer"'s queue.
+
+    Parameters
+    ----------
+    job_change_event:
+        AWS Batch job change event details (similar to "DescribeJob" response).
+    logs_bucket:
+        Push job attempt logs to this bucket.
+    logs_prefix:
+        Push job attempt logs to the bucket under this prefix.
+    retry_queue_url:
+        Publish failed & retryable granule processing events to this queue for
+        requeuing.
+    failure_dlq_url:
+        Publish failed, nonretryable granule processing events to this queue
+        for manual inspection.
     """
     sqs = boto3.client("sqs")
 
@@ -63,20 +80,25 @@ def job_monitor(
         bucket=logs_bucket,
         logs_prefix=logs_prefix,
     )
-
     granule_logger.put_event_details(details)
 
     if outcome == JobOutcome.FAILURE_RETRYABLE:
-        sqs.send_message(
-            QueueUrl=retry_queue_url,
-            MessageBody=granule_event.new_attempt().to_json(),
-            MessageAttributes={
-                "FailureType": {
-                    "StringValue": "RETRYABLE",
-                    "DataType": "String",
-                }
-            },
-        )
+        if details.attempts == details.max_attempts:
+            sqs.send_message(
+                QueueUrl=retry_queue_url,
+                MessageBody=granule_event.new_attempt().to_json(),
+                MessageAttributes={
+                    "FailureType": {
+                        "StringValue": "RETRYABLE",
+                        "DataType": "String",
+                    }
+                },
+            )
+        else:
+            logger.info(
+                f"Ignoring retryable failure on attempt={details.attempts} which will "
+                f"be retried for a maximum of {details.max_attempts} attempts. "
+            )
     elif outcome == JobOutcome.FAILURE_NONRETRYABLE:
         sqs.send_message(
             QueueUrl=failure_dlq_url,
@@ -93,9 +115,9 @@ def job_monitor(
 def handler(event: JobChangeEvent, context: Any) -> None:
     """Event handler for AWS Batch "job state change" events"""
     return job_monitor(
+        job_change_event=event,
         logs_bucket=os.environ["PROCESSING_BUCKET_NAME"],
         logs_prefix=os.environ.get("PROCESSING_BUCKET_LOG_PREFIX", "logs"),
         retry_queue_url=os.environ["JOB_RETRY_QUEUE_URL"],
         failure_dlq_url=os.environ["JOB_FAILURE_DLQ_URL"],
-        job_change_event=event,
     )

--- a/src/job_monitor/handler.py
+++ b/src/job_monitor/handler.py
@@ -83,7 +83,7 @@ def job_monitor(
     granule_logger.put_event_details(details)
 
     if outcome == JobOutcome.FAILURE_RETRYABLE:
-        if details.attempts == details.max_attempts:
+        if details.job_attempts == details.max_attempts:
             sqs.send_message(
                 QueueUrl=retry_queue_url,
                 MessageBody=granule_event.new_attempt().to_json(),
@@ -96,8 +96,8 @@ def job_monitor(
             )
         else:
             logger.info(
-                f"Ignoring retryable failure on attempt={details.attempts} which will "
-                f"be retried for a maximum of {details.max_attempts} attempts. "
+                f"Ignoring retryable failure on attempt={details.job_attempts} which "
+                f"will be retried for a maximum of {details.max_attempts} attempts. "
             )
     elif outcome == JobOutcome.FAILURE_NONRETRYABLE:
         sqs.send_message(

--- a/tests/common/test_aws_batch.py
+++ b/tests/common/test_aws_batch.py
@@ -27,6 +27,7 @@ class TestJobDetail:
     def test_attempts(self, detail: JobDetailTypeDef, attempts: int) -> None:
         job_detail = JobDetails(detail)
         assert job_detail.attempts == attempts
+        assert job_detail.max_attempts == 3
 
     @pytest.mark.parametrize(
         ["detail", "exit_code"],

--- a/tests/common/test_aws_batch.py
+++ b/tests/common/test_aws_batch.py
@@ -26,7 +26,7 @@ class TestJobDetail:
     )
     def test_attempts(self, detail: JobDetailTypeDef, attempts: int) -> None:
         job_detail = JobDetails(detail)
-        assert job_detail.attempts == attempts
+        assert job_detail.job_attempts == attempts
         assert job_detail.max_attempts == 3
 
     @pytest.mark.parametrize(

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -62,7 +62,7 @@ def test_handler_retryable_failure_last_attempt(
     """
     event = event_job_detail_change_failed.copy()
     event["detail"] = job_detail_failed_spot
-    event["detail"]["attempts"] = [event["detail"]["attempts"]] * 3
+    event["detail"]["attempts"] = [event["detail"]["attempts"][0]] * 3
 
     job_monitor(
         job_change_event=event,
@@ -96,7 +96,7 @@ def test_handler_retryable_failure_doesnt_requeue_nonfinal_attempt(
     """
     event = event_job_detail_change_failed.copy()
     event["detail"] = job_detail_failed_spot
-    event["detail"]["attempts"] = [event["detail"]["attempts"]] * 1
+    event["detail"]["attempts"] = [event["detail"]["attempts"][0]] * 1
 
     job_monitor(
         job_change_event=event,

--- a/tests/test_job_monitor.py
+++ b/tests/test_job_monitor.py
@@ -31,11 +31,11 @@ def test_handler_logs_nonretryable_failure(
     )
 
     job_monitor(
-        job_logger.bucket,
-        job_logger.logs_prefix,
+        job_change_event=event,
+        logs_bucket=job_logger.bucket,
+        logs_prefix=job_logger.logs_prefix,
         retry_queue_url=retry_queue,
         failure_dlq_url=failure_dlq,
-        job_change_event=event,
     )
 
     messages = sqs.receive_message(QueueUrl=failure_dlq)["Messages"]
@@ -46,7 +46,7 @@ def test_handler_logs_nonretryable_failure(
     assert ProcessingOutcome.SUCCESS not in events
 
 
-def test_handler_logs_retryable_failure(
+def test_handler_retryable_failure_last_attempt(
     granule_id: GranuleId,
     job_logger: GranuleLoggerService,
     sqs: SQSClient,
@@ -55,19 +55,59 @@ def test_handler_logs_retryable_failure(
     event_job_detail_change_failed: JobChangeEvent,
     job_detail_failed_spot: JobDetailTypeDef,
 ) -> None:
-    """Test the handler"""
+    """Test behavior for Spot failure on last AWS Batch attempt
+
+    The handler should log the attempt AND requeue it since AWS Batch won't
+    retry it internally.
+    """
     event = event_job_detail_change_failed.copy()
     event["detail"] = job_detail_failed_spot
+    event["detail"]["attempts"] = [event["detail"]["attempts"]] * 3
+
     job_monitor(
-        job_logger.bucket,
-        job_logger.logs_prefix,
+        job_change_event=event,
+        logs_bucket=job_logger.bucket,
+        logs_prefix=job_logger.logs_prefix,
         retry_queue_url=retry_queue,
         failure_dlq_url=failure_dlq,
-        job_change_event=event,
     )
 
     messages = sqs.receive_message(QueueUrl=retry_queue)["Messages"]
     assert len(messages) == 1
+
+    events = job_logger.list_events(granule_id)
+    assert len(events[ProcessingOutcome.FAILURE]) == 1
+    assert ProcessingOutcome.SUCCESS not in events
+
+
+def test_handler_retryable_failure_doesnt_requeue_nonfinal_attempt(
+    granule_id: GranuleId,
+    job_logger: GranuleLoggerService,
+    sqs: SQSClient,
+    retry_queue: str,
+    failure_dlq: str,
+    event_job_detail_change_failed: JobChangeEvent,
+    job_detail_failed_spot: JobDetailTypeDef,
+) -> None:
+    """Test behavior for Spot failure on last AWS Batch attempt
+
+    The handler should log the attempt and does NOT requeue it since AWS Batch will
+    retry it internally.
+    """
+    event = event_job_detail_change_failed.copy()
+    event["detail"] = job_detail_failed_spot
+    event["detail"]["attempts"] = [event["detail"]["attempts"]] * 1
+
+    job_monitor(
+        job_change_event=event,
+        logs_bucket=job_logger.bucket,
+        logs_prefix=job_logger.logs_prefix,
+        retry_queue_url=retry_queue,
+        failure_dlq_url=failure_dlq,
+    )
+
+    messages = sqs.receive_message(QueueUrl=retry_queue).get("Messages", [])
+    assert len(messages) == 0
 
     events = job_logger.list_events(granule_id)
     assert len(events[ProcessingOutcome.FAILURE]) == 1
@@ -86,11 +126,11 @@ def test_handler_logs_success(
     event = event_job_detail_change_failed.copy()
     event["detail"]["container"]["exitCode"] = 0
     job_monitor(
-        job_logger.bucket,
-        job_logger.logs_prefix,
+        job_change_event=event,
+        logs_bucket=job_logger.bucket,
+        logs_prefix=job_logger.logs_prefix,
         retry_queue_url=retry_queue,
         failure_dlq_url=failure_dlq,
-        job_change_event=event,
     )
 
     events = job_logger.list_events(granule_id)


### PR DESCRIPTION
## What I am changing

This PR fixes an issue where our job monitoring system would queue a job for retry before the last attempt was reached. Our AWS Batch jobs have a "retryStrategy" configured that will automatically retry the job for ephemeral issues like Spot market interruptions. We used to have a filter to only listen to events on the last retry, but this had to be removed because we don't want to retry ordinary non-zero exit statuses since those shouldn't be automatically retryable (e.g., a bug in our program). Accordingly we need to filter retryable failures so we only queue a retry when the last "internal AWS Batch retry" has been reached.


## How I did it

* 🧹🧹🧹🧹🧹
    * Remove some unused settings to cleanup along the way
    * I also changed the handler function to require named arguments since there were so many
* Surface the "max attempts" from the retry strategy from the AWS Batch job event description
* Add a filter to the job monitor function
* 📈 deploy CE with Container Insights enabled

## How you can test it

Added a unit test to make sure the behavior works
```
uv run pytest tests/test_job_monitor.py
```