### PR TITLE
Test name missing test prefix not discovered by pytest.

### DIFF
--- a/tests/common/test_models.py
+++ b/tests/common/test_models.py
@@ -36,7 +36,7 @@ class TestGranuleProcessingEvent:
     """Test GranuleProcessingEvent"""
 
     @pytest.mark.parametrize("debug_bucket", ["foo", None])
-    def to_from_envvar(self, debug_bucket: str | None) -> None:
+    def test_to_from_envvar(self, debug_bucket: str | None) -> None:
         event = GranuleProcessingEvent(
             granule_id="foo",
             attempt=42,


### PR DESCRIPTION
## What I am changing
Adding the "test" prefix to the to_from_envar model test.

## How you can test it
Run the test suite.
