### PR TITLE
fix: bump AL2 to AL2023 for EcsMachineImage

### DIFF
--- a/cdk/hls_constructs/aws_batch_infra.py
+++ b/cdk/hls_constructs/aws_batch_infra.py
@@ -76,7 +76,7 @@ class BatchInfra(Construct):
             ec2_machine_image = ec2.MachineImage.lookup(name=ami_id)
         ecs_machine_image = batch.EcsMachineImage(
             image=ec2_machine_image,
-            image_type=batch.EcsMachineImageType.ECS_AL2,
+            image_type=batch.EcsMachineImageType.ECS_AL2023,
         )
         launch_template = ec2.LaunchTemplate(
             self,


### PR DESCRIPTION
## What I am changing

Bumps the `EcsMachineImage` from AL2 (deprecated) to AL2023 to get out ahead of scheduled migration action by AWS.